### PR TITLE
Replace HTML entities with Material Icons

### DIFF
--- a/ckan-widget/package.json
+++ b/ckan-widget/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "axios": "^0.18.0",
     "bootstrap": "^4.1.3",
+    "material-icons-react": "^1.0.2",
     "react": "^16.4.2",
     "react-autocomplete": "^1.8.1",
     "react-bootstrap": "^0.32.1",

--- a/ckan-widget/src/App.css
+++ b/ckan-widget/src/App.css
@@ -10,7 +10,7 @@
 .datasets-total {
   float: left;
 }
-.menu { 
+.menu {
   position: absolute;
   width: 100%;
   z-index: 1000;
@@ -20,7 +20,20 @@
 }
 
 .material-icons {
-  display: inline;
+  vertical-align: middle;
+}
+
+.header-icon > .material-icons{
+  position: absolute;
+  top: 26%;
+  left: -4%;
+  opacity: 0.2;
+  line-height: 0.5;
+  z-index: 0;
+}
+
+.header-icon > .material-icons.md-24{
+  font-size: 15rem;
 }
 
 .dataset-wrap.collapsed {

--- a/ckan-widget/src/App.js
+++ b/ckan-widget/src/App.js
@@ -1,13 +1,13 @@
-import React, { Component } from 'react';
-import './App.css';
-import DatasetSearchBar from './components/container/DatasetSearchBar';
-import DatasetInfoList from './components/container/DatasetInfoList';
-import FacetList from './components/container/FacetList';
-import DatasetSort from './components/container/DatasetSort';
+import React, { Component } from 'react'
+import './App.css'
+import DatasetSearchBar from './components/container/DatasetSearchBar'
+import DatasetInfoList from './components/container/DatasetInfoList'
+import FacetList from './components/container/FacetList'
+import DatasetSort from './components/container/DatasetSort'
 import TotalDatasets from './components/container/TotalDatasets'
 import DatasetsPerPage from './components/container/DatasetsPerPage'
 import Pagination from './components/container/Pagination'
-
+import MaterialIcon from 'material-icons-react'
 
 class App extends Component {
     render() {
@@ -15,11 +15,14 @@ class App extends Component {
 
         return (
         <div className="App">
-            <div className="bg-secondary">
+            <div className="bg-secondary header">
                 <div className="container-fluid">
                     <div className="row">
                         <div className="col-lg-10 offset-lg-1">
                             <DatasetSearchBar />
+                            <span className="header-icon">
+                                <MaterialIcon icon="search" color="#fff" />
+                            </span>
                         </div>
                     </div>
                 </div>

--- a/ckan-widget/src/components/container/DatasetsPerPage.js
+++ b/ckan-widget/src/components/container/DatasetsPerPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-
+import MaterialIcon from 'material-icons-react'
 import * as actions from '../../actions'
 
 export class DatasetsPerPage extends Component {
@@ -15,7 +15,9 @@ export class DatasetsPerPage extends Component {
       <div className="ml-0">
         <div className="input-group">
           <div className="input-group-prepend">
-            <label htmlFor="datasets_per_page" title="Results per page" className="input-group-text">&#8801;</label>
+            <label htmlFor="datasets_per_page" title="Results per page" className="input-group-text">
+                <MaterialIcon icon="list" />
+            </label>
           </div>
           <select id="datasets_per_page" className="custom-select" value={this.props.rows} onChange={this.handleOnChange}>
             <option value='10'>10</option>

--- a/ckan-widget/src/components/presentational/DatasetDetails.js
+++ b/ckan-widget/src/components/presentational/DatasetDetails.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import MaterialIcon from 'material-icons-react'
 
 class DatasetDetails extends Component {
     renderResources = (resources, datasetName) => {
@@ -53,7 +54,10 @@ class DatasetDetails extends Component {
                         { this.renderResources(resources, name) }
                     </ul>
                 </div>
-                <a className="btn btn-success mb-1" href={`https://trouver.datasud.fr/dataset/${name}`}>View on Datasud.fr</a>
+                <a className="btn btn-success mb-1" href={`https://trouver.datasud.fr/dataset/${name}`}>
+                    <MaterialIcon icon="open_in_new" size="tiny" color="#fff" />
+                    <span className="ml-1">View on Datasud.fr</span>
+                </a>
             </div>
         )
     }

--- a/ckan-widget/src/components/presentational/DatasetInfo.js
+++ b/ckan-widget/src/components/presentational/DatasetInfo.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import DatasetDetails from '../presentational/DatasetDetails'
+import MaterialIcon from 'material-icons-react'
 
 
 class DatasetInfo extends Component{
@@ -51,24 +52,17 @@ class DatasetInfo extends Component{
         return null
     }
 
-    renderArrow = collapsed => {
-        if (collapsed) {
-            return (<p className="material-icons">&#8675;</p>)
-        } else {
-            return (<p className="material-icons">&#8673;</p>)
-        }
-    }
-
     render(){
         const { title, notes, metadata_modified, datatype, resources, thumbnail } = this.props
         const datetime = this.formatDate(metadata_modified)
         const formats = this.findFormats(resources)
         const collapseClass = this.state.collapsed ? '' : 'collapsed'
+        const expandArrow = this.state.collapsed ? 'expand_more' : 'expand_less'
 
         return(
             <div className={"card dataset-wrap my-3 " + collapseClass}>
                 <div className="dataset card-body" onClick={this.handleDatasetClick}>
-                    { this.renderArrow(this.state.collapsed) }
+                    <MaterialIcon icon={expandArrow} />
                     <div className="row">
                         { this.renderThumbnail(thumbnail) }
                         <div className="col-lg-9">

--- a/ckan-widget/src/components/presentational/Error.js
+++ b/ckan-widget/src/components/presentational/Error.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import MaterialIcon from 'material-icons-react'
 
 class Error extends Component {
     constructor() {
@@ -16,7 +17,7 @@ class Error extends Component {
                 <div className="my-3 alert alert-warning alert-dismissible" role="alert">
                     <strong>Upps, error!</strong> {this.props.error};
                     <button type="button" className="close" data-dismiss="alert" aria-label="Close" onClick={this.handleClose}>
-                        <span aria-hidden="true">&times;</span>
+                    <MaterialIcon icon="close" size="tiny" color="inherit" />
                     </button>
                 </div>
             )

--- a/ckan-widget/src/components/presentational/Facet.js
+++ b/ckan-widget/src/components/presentational/Facet.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-
+import MaterialIcon from 'material-icons-react'
 
 class Facet extends Component {
   constructor(props) {
@@ -11,18 +11,11 @@ class Facet extends Component {
     this.setState({ collapsed: !this.state.collapsed })
   }
 
-  renderArrow = collapsed => {
-    if (collapsed) {
-      return (<p className="material-icons mr-1">&#8615;</p>)
-    } else {
-      return (<p className="material-icons mr-1">&#8613;</p>)
-    }
-  }
-
   render() {
     const facets = this.props.facetsInfo;
     const title = this.props.title;
     const collapseClass = this.state.collapsed ? 'collapse' : ''
+    let expandArrow = this.state.collapsed ? 'expand_more' : 'expand_less'
     let expandLabel = this.state.collapsed ? 'Expand' : 'Contract'
 
     let fixedList = []
@@ -32,7 +25,10 @@ class Facet extends Component {
     if (facets.length > 7){
       expandControls.push(
           <div className="card-footer px-0 py-0" key={9999}>
-          <a className="btn btn-link" onClick={this.expandFacetList}>{this.renderArrow(this.state.collapsed)}{expandLabel}</a>
+          <a className="btn btn-link" onClick={this.expandFacetList}>
+              <MaterialIcon icon={expandArrow} color="inherit" size="tiny" />
+              <span className="ml-1">{expandLabel}</span>
+          </a>
           </div>
       )
     }

--- a/ckan-widget/src/components/presentational/SearchBar.js
+++ b/ckan-widget/src/components/presentational/SearchBar.js
@@ -40,7 +40,7 @@ class SearchBar extends Component{
                         placeholder: 'Search datasets',
                         className: 'form-control form-control-lg border-0'
                     }}
-                    wrapperStyle={{ position: 'relative'}}
+                    wrapperStyle={{ position: 'relative', zIndex: 1 }}
                     value={this.state.value}
                     items={this.state.suggestions}
                     open={( this.state.value.length >= 1 && this.state.isOpen )}

--- a/ckan-widget/src/components/presentational/SelectedFacet.js
+++ b/ckan-widget/src/components/presentational/SelectedFacet.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import MaterialIcon from 'material-icons-react';
 
 class SelectedFacet extends Component {
 
@@ -10,7 +11,7 @@ class SelectedFacet extends Component {
       return (
         <li className="list-inline-item btn btn-primary" onClick={e => this.props.onClick(facet)}>
           <span className="mx-2">{name}</span>
-          <p className="material-icons">&#9932;</p>
+          <MaterialIcon icon="close" size="tiny" />
         </li>
       );
     }

--- a/ckan-widget/src/components/presentational/Sort.js
+++ b/ckan-widget/src/components/presentational/Sort.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import MaterialIcon from 'material-icons-react';
 
 class Sort extends Component {
   render() {
@@ -6,7 +7,7 @@ class Sort extends Component {
       <div className="mr-0">
       <div className="input-group">
         <div className="input-group-prepend">
-            <label htmlFor="order_by" title="Order by" className="input-group-text">&#8645;</label>
+            <label htmlFor="order_by" title="Order by" className="input-group-text"><MaterialIcon icon="sort" /></label>
         </div>
         <select id="order_by" className="custom-select" value={this.props.sort} onChange={e => this.props.handleSort(e.target.value)}>
           <option value="score desc, metadata_modified desc">Relevance</option>

--- a/ckan-widget/src/index.js
+++ b/ckan-widget/src/index.js
@@ -71,6 +71,6 @@ export { instance as ckanWidget };
 
 // Run the Widget locally for testing purposes
 // instance.init(localConfig)
-instance.init()
+// instance.init()
 
 registerServiceWorker();

--- a/ckan-widget/src/index.js
+++ b/ckan-widget/src/index.js
@@ -71,6 +71,6 @@ export { instance as ckanWidget };
 
 // Run the Widget locally for testing purposes
 // instance.init(localConfig)
-// instance.init()
+instance.init()
 
 registerServiceWorker();


### PR DESCRIPTION
This PR replaces HTML entities with Material Icons and improves the overall visual design. Minor refactoring to the existing React components and styling is applied.

`npm install` is required after merging, since the `material-icons-react` React component needs to be added.