### PR TITLE
Add link_to_ckan_href/link_to_ckan_label + few fixs

### DIFF
--- a/readme-fr.md
+++ b/readme-fr.md
@@ -105,6 +105,8 @@ Exemple de page HTML :
   <script type="text/javascript">
     var config = {
       ckan_api: 'https://ckan-api.com',
+      link_to_ckan_href: 'https://ckan-site/path-datasets/{name}/',
+      link_to_ckan_label: 'Voir sur le catalogue CKAN',
       ckan_organizations: ['org1', 'org2'],
       ckan_groups: ['group1'],
       ckan_tags: ['tag1'],
@@ -112,9 +114,12 @@ Exemple de page HTML :
         res_format: 'HTML',
         datatype: 'type'
       },
+      facet_display: ['facet1','facet1','facet3'],
       data_sort: 'title_string asc',
       result_page_size: 25,
-      thumbnails_display: true
+      thumbnails_display: true,
+      header_display: true,
+      sidebar_display: true
     }
 
     // Will run the Widget with custom configuration
@@ -144,6 +149,8 @@ Le Widget charge la configuration renseignée dans la fonction `init` au démarr
 ```
 var config = {
       ckan_api: 'https://ckan-api.com',
+      link_to_ckan_href: 'https://ckan-site/path-datasets/{name}/',
+      link_to_ckan_label: 'Voir sur le catalogue CKAN',
       ckan_organizations: ['org1', 'org2'],
       ckan_groups: ['group1'],
       ckan_tags: ['tag1'],
@@ -155,8 +162,8 @@ var config = {
       data_sort: 'title_string asc',
       result_page_size: 25,
       thumbnails_display: true,
-      display_header: true,
-      display_sidebar: true
+      header_display: true,
+      sidebar_display: true
     }
 ```
 
@@ -171,17 +178,19 @@ var config = {
 
 Propriétés de configuration :
 
-* **ckan-api** : URL de l’API de Ckan. Par défaut, `trouver.datasud.fr`.
-* **ckan-organizations** : noms des organisations CKAN à récupérer. Par défaut All. Sinon, liste des ID des organisations séparés par des virgules.
-* **ckan-groups** : noms de groupes CKAN à récupérer. Par défaut All. Sinon, liste des ID de groupes séparés par des virgules.
-* **ckan-facets** : paire de valeurs clés à utiliser pour filtrer les champs.
-* **ckan-tags** : noms des tags CKAN à récupérer. Par défaut All. Sinon, liste d’identifiants séparés par des virgules.
-* **facet-display** : liste des champs à afficher dans le widget. Par défaut all. Sinon, liste de noms de champs séparés par des virgules.
-* **data-sort** : mode de tri à utiliser. Identique à ceux de CKAN (popularité, pertinence, last_modified, alpha…). La valeur par défaut est `score desc, metadata_modified desc`.
-* **result-page-size** : nombre de résultats par page (10, 25, 50, 100). Valeur par défaut : `10`. Maximum : `100`.
-* **thumbnails-display** : booléen. Affichage de la vignette de l’ensemble de données. Par défaut `true`.
-* **header-display** : booléen. Affichage de l’en-tête du widget et de la barre de recherche.
-* **sidebar-display** : booléen. Affichage de la barre latérale.
+* **ckan_api** : URL de l’API de Ckan. Par défaut, `trouver.datasud.fr`.
+* **link_to_ckan_href** : pattern de l'URL d'une fiche dans le catalogue CKAN,
+* **link_to_ckan_label** : libellé qui sera affiché sur le lien pour ouvrir la fiche dans le catalogue CKAN,
+* **ckan_organizations** : noms des organisations CKAN à récupérer. Par défaut All. Sinon, liste des ID des organisations séparés par des virgules.
+* **ckan_groups** : noms de groupes CKAN à récupérer. Par défaut All. Sinon, liste des ID de groupes séparés par des virgules.
+* **ckan_tags** : noms des tags CKAN à récupérer. Par défaut All. Sinon, liste d’identifiants séparés par des virgules.
+* **ckan_facets** : paire de valeurs clés à utiliser pour filtrer les champs.
+* **facet_display** : liste des champs à afficher dans le widget. Par défaut all. Sinon, liste de noms de champs séparés par des virgules.
+* **data_sort** : mode de tri à utiliser. Identique à ceux de CKAN (popularité, pertinence, last_modified, alpha…). La valeur par défaut est `score desc, metadata_modified desc`.
+* **result_page_size** : nombre de résultats par page (10, 25, 50, 100). Valeur par défaut : `10`. Maximum : `100`.
+* **thumbnails_display** : booléen. Affichage de la vignette de l’ensemble de données. Par défaut `true`.
+* **header_display** : booléen. Affichage de l’en-tête du widget et de la barre de recherche.
+* **sidebar_display** : booléen. Affichage de la barre latérale.
 
 ### Définir la clé API
 

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Requierments: proceed with instalation
 * Update the version number in ckan-widget/package.json
 * Delete the build folder : `rm -Rf build`
 * Build : `cd ckan-widget/ ; npm run build`
-* Update the build id in this document and that the HTML snippets match the index.html generate by the build 
+* Update the build id in this document and that the HTML snippets match the index.html generate by the build
 * Commit
 * Tag
 * Push on Github.com
@@ -104,6 +104,8 @@ Using the `public/app.css` you can change the style of the Widget. HTML page exa
   <script type="text/javascript">
     var config = {
       ckan_api: 'https://ckan-api.com',
+      link_to_ckan_href: 'https://ckan-site/path-datasets/{name}/',
+      link_to_ckan_label: 'View on CKAN catalog',
       ckan_organizations: ['org1', 'org2'],
       ckan_groups: ['group1'],
       ckan_tags: ['tag1'],
@@ -111,9 +113,12 @@ Using the `public/app.css` you can change the style of the Widget. HTML page exa
         res_format: 'HTML',
         datatype: 'type'
       },
+      facet_display: ['facet1','facet1','facet3'],
       data_sort: 'title_string asc',
       result_page_size: 25,
-      thumbnails_display: true
+      thumbnails_display: true,
+      header_display: true,
+      sidebar_display: true
     }
 
     // Will run the Widget with custom configuration
@@ -141,6 +146,8 @@ The Widget loads the configuration that is passed to the `init` function at star
 ```
 var config = {
       ckan_api: 'https://ckan-api.com',
+      link_to_ckan_href: 'https://ckan-site/path-datasets/{name}/',
+      link_to_ckan_label: 'View on CKAN catalog',
       ckan_organizations: ['org1', 'org2'],
       ckan_groups: ['group1'],
       ckan_tags: ['tag1'],
@@ -168,17 +175,19 @@ var config = {
 
 Configuration properties:
 
-* **ckan-api**: Ckan API URL. Default to the `trouver.datasud.fr` one.
-* **ckan-organizations**: CKAN Organizations names to be retrieved. Default to All. Else, comma separated list of Organizations IDs.
-* **ckan-groups**: CKAN Groups names to be retrieved. Default to All. Else, comma separated list of Groups IDs.
-* **ckan-facets**: key-values pair to be used to filter on the facets.
-* **ckan-tags**: CKAN Tags names to be retrieved. Default to All. Else, comma separated list of Tags IDs.
-* **facet-display**: list of the facets to be displayed in the widget. Default to all. Else, comma separated list of facets names.
-* **data-sort**: sorting mode to be used. Same than the CKAN ones (popularity, relevance, last_modified, alpha…). Default to `score desc, metadata_modified desc`.
-* **result-page-size**: number of results per page(10, 25, 50, 100). Default to `10`. Max to `100`.
-* **thumbnails-display**: boolean. Whether to display dataset's thumbnail or not. Default to `true`.
-* **header-display**: boolean. Whether to display widget header and search bar
-* **sidebar-display**: boolean. Whether to display the sidebar
+* **ckan_api**: Ckan API URL. Default to the `trouver.datasud.fr` one.
+* **link_to_ckan_href** : URL pattern of a record in the CKAN catalog,
+* **link_to_ckan_label** : wording that will be displayed on the link to open the dataset in the CKAN catalog,
+* **ckan_organizations**: CKAN Organizations names to be retrieved. Default to All. Else, comma separated list of Organizations IDs.
+* **ckan_groups**: CKAN Groups names to be retrieved. Default to All. Else, comma separated list of Groups IDs.
+* **ckan_facets**: key-values pair to be used to filter on the facets.
+* **ckan_tags**: CKAN Tags names to be retrieved. Default to All. Else, comma separated list of Tags IDs.
+* **facet_display**: list of the facets to be displayed in the widget. Default to all. Else, comma separated list of facets names.
+* **data_sort**: sorting mode to be used. Same than the CKAN ones (popularity, relevance, last_modified, alpha…). Default to `score desc, metadata_modified desc`.
+* **result_page_size**: number of results per page(10, 25, 50, 100). Default to `10`. Max to `100`.
+* **thumbnails_display**: boolean. Whether to display dataset's thumbnail or not. Default to `true`.
+* **header_display**: boolean. Whether to display widget header and search bar
+* **sidebar_display**: boolean. Whether to display the sidebar
 
 
 ### Set API Key

--- a/readme.md
+++ b/readme.md
@@ -159,8 +159,8 @@ var config = {
       data_sort: 'title_string asc',
       result_page_size: 25,
       thumbnails_display: true,
-      display_header: true,
-      display_sidebar: true
+      header_display: true,
+      sidebar_display: true
     }
 ```
 


### PR DESCRIPTION
Ajout des variables de configuration qui manquaient : link_to_ckan_href et link_to_ckan_label
Correction du nom des variables dans "Configuration properties" (tiret bas au lieu du tiret haut)
Il manque encore une information que je n'ai pas sur les valeurs par défaut de certaines variables